### PR TITLE
Wait for copyFile to be finished before unlink the file

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -98,7 +98,7 @@ class ServerlessPlugin implements Plugin {
   async _restoreBackups(): Promise<void> {
     await Promise.all(
       this._filesToBackup().map(async (file) => {
-        copyFile(`${file}.org`, file);
+        await copyFile(`${file}.org`, file);
         unlink(`${file}.org`);
       })
     );


### PR DESCRIPTION
Since the copy file operation is asynchronous we need to wait before we delete the source file. 
Sometimes with the very busy system I have received this error:

```
  Error: ENOENT: no such file or directory, copyfile 'xxxx.js.org' -> 'xxxx.js'
```